### PR TITLE
Allows spaces in filenames, and no need for output.

### DIFF
--- a/Audible DRM Cracker/MainWindow.xaml
+++ b/Audible DRM Cracker/MainWindow.xaml
@@ -5,26 +5,24 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Audible_DRM_Cracker"
         mc:Ignorable="d"
-        Title="Audible DRM Cracker" Height="300" Width="550" WindowStartupLocation="CenterScreen" Icon="ADC.ico" ResizeMode="NoResize">
+        Title="Audible DRM Cracker" Height="277.6" Width="550" WindowStartupLocation="CenterScreen" Icon="ADC.ico" ResizeMode="NoResize">
     <Grid>
         <Button x:Name="inpbutton" Content="Choose .aax" HorizontalAlignment="Left" Margin="315,10,0,0" VerticalAlignment="Top" Width="75" Height="23" Click="Button_Click_2"/>
-        <Button x:Name="outpbutton" Content="Output File" HorizontalAlignment="Left" Margin="315,38,0,0" VerticalAlignment="Top" Width="75" Height="23" Click="Button_Click_3" IsEnabled="False"/>
         <TextBox x:Name="inputdisplay" HorizontalAlignment="Left" Height="23" Margin="10,10,0,0" Text="" VerticalAlignment="Top" Width="300"/>
-        <TextBox x:Name="outputdisplay" HorizontalAlignment="Left" Height="23" Margin="10,38,0,0" Text="" VerticalAlignment="Top" Width="300"/>
-        <Button Content="Info" HorizontalAlignment="Left" Margin="448,10,0,0" VerticalAlignment="Top" Width="75" Height="23" Click="Button_Click"/>
-        <Button Content="Donate" HorizontalAlignment="Left" Margin="448,38,0,0" VerticalAlignment="Top" Width="75" Height="23" Click="Button_Click_1"/>
-        <Button x:Name="convertbutton" Content="Remove AAX DRM" HorizontalAlignment="Left" Margin="315,68,0,0" VerticalAlignment="Top" Width="208" Height="50" IsEnabled="False" Click="convertbutton_Click"/>
-        <TextBox x:Name="txtConsole" HorizontalAlignment="Left" Height="79" Margin="10,180,0,0" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" VerticalAlignment="Top" Width="513" Background="Black" Foreground="White" AcceptsReturn="True" IsReadOnly="True"/>
-        <ProgressBar x:Name="pbar" HorizontalAlignment="Left" Height="25" Margin="10,150,0,0" VerticalAlignment="Top" Width="513"/>
-        <Slider x:Name="qslider" HorizontalAlignment="Left" Margin="185,96,0,0" VerticalAlignment="Top" Width="125" Maximum="320" Minimum="32" IsSnapToTickEnabled="True" TickPlacement="BottomRight" Ticks="32,80,96,128,160,192,256,320" Value="80" IsEnabled="False"/>
-        <Label x:Name="sqlbl" Content="Set MP3/AAC Quality:" HorizontalAlignment="Left" Margin="185,62,0,0" VerticalAlignment="Top" IsEnabled="False"/>
-        <Label x:Name="curqlbl" Content="Current:" HorizontalAlignment="Left" Margin="185,114,0,0" VerticalAlignment="Top" IsEnabled="False"/>
-        <Label x:Name="qlabel" Content="{Binding ElementName=qslider, Path=Value}" ContentStringFormat="{}{0:#}" HorizontalAlignment="Left" Margin="237,114,0,0" VerticalAlignment="Top" Width="35" IsEnabled="False"/>
-        <RadioButton x:Name="rmp3" Content="LAME MP3" HorizontalAlignment="Left" Margin="10,68,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked"/>
-        <RadioButton x:Name="raac" Content="AAC AUDIO" HorizontalAlignment="Left" Margin="10,93,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked_1"/>
-        <RadioButton x:Name="rflac" Content="FLAC" HorizontalAlignment="Left" Margin="10,120,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked_2"/>
-        <Label x:Name="kblbl" Content="kbit/s" HorizontalAlignment="Left" Margin="260,114,0,0" VerticalAlignment="Top" IsEnabled="False"/>
-        <Label Content="Status:" HorizontalAlignment="Left" Margin="315,114,0,0" VerticalAlignment="Top"/>
-        <Label x:Name="statuslbl" Content="" HorizontalAlignment="Left" Margin="360,114,0,0" VerticalAlignment="Top" Width="163"/>
+        <Button Content="Info" HorizontalAlignment="Left" Margin="402,10,0,0" VerticalAlignment="Top" Width="55" Height="23" Click="Button_Click"/>
+        <Button Content="Donate" HorizontalAlignment="Left" Margin="468,10,0,0" VerticalAlignment="Top" Width="55" Height="23" Click="Button_Click_1"/>
+        <Button x:Name="convertbutton" Content="Remove AAX DRM" HorizontalAlignment="Left" Margin="315,38,0,0" VerticalAlignment="Top" Width="208" Height="50" IsEnabled="False" Click="convertbutton_Click"/>
+        <TextBox x:Name="txtConsole" HorizontalAlignment="Left" Height="79" Margin="10,150,0,0" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" VerticalAlignment="Top" Width="513" Background="Black" Foreground="White" AcceptsReturn="True" IsReadOnly="True"/>
+        <ProgressBar x:Name="pbar" HorizontalAlignment="Left" Height="25" Margin="10,120,0,0" VerticalAlignment="Top" Width="513"/>
+        <Slider x:Name="qslider" HorizontalAlignment="Left" Margin="185,66,0,0" VerticalAlignment="Top" Width="125" Maximum="320" Minimum="32" IsSnapToTickEnabled="True" TickPlacement="BottomRight" Ticks="32,80,96,128,160,192,256,320" Value="80" IsEnabled="False"/>
+        <Label x:Name="sqlbl" Content="Set MP3/AAC Quality:" HorizontalAlignment="Left" Margin="185,32,0,0" VerticalAlignment="Top" IsEnabled="False"/>
+        <Label x:Name="curqlbl" Content="Current:" HorizontalAlignment="Left" Margin="185,84,0,0" VerticalAlignment="Top" IsEnabled="False"/>
+        <Label x:Name="qlabel" Content="{Binding ElementName=qslider, Path=Value}" ContentStringFormat="{}{0:#}" HorizontalAlignment="Left" Margin="237,84,0,0" VerticalAlignment="Top" Width="35" IsEnabled="False"/>
+        <RadioButton x:Name="rmp3" Content="LAME MP3" HorizontalAlignment="Left" Margin="10,38,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked" IsChecked="True"/>
+        <RadioButton x:Name="raac" Content="AAC AUDIO" HorizontalAlignment="Left" Margin="10,63,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked_1"/>
+        <RadioButton x:Name="rflac" Content="FLAC" HorizontalAlignment="Left" Margin="10,90,0,0" VerticalAlignment="Top" Checked="RadioButton_Checked_2"/>
+        <Label x:Name="kblbl" Content="kbit/s" HorizontalAlignment="Left" Margin="260,84,0,0" VerticalAlignment="Top" IsEnabled="False"/>
+        <Label Content="Status:" HorizontalAlignment="Left" Margin="315,84,0,0" VerticalAlignment="Top"/>
+        <Label x:Name="statuslbl" Content="" HorizontalAlignment="Left" Margin="360,84,0,0" VerticalAlignment="Top" Width="163"/>
     </Grid>
 </Window>


### PR DESCRIPTION
- Removed the need to select an output, as the dialogue window wasn't very helpful as it suggested the MP3 needed to exist. It now will take the same name as the original but use the new extension.

- Removed the need to have no spaces in the title. This was done by creating a temporary file without spaces.

- Set window not to resize